### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "UserReport",
+    platforms: [
+        .iOS(.v9)
+    ],
+    products: [
+        .library(
+            name: "UserReport",
+            targets: ["UserReportSDK"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "UserReportSDK",
+            dependencies: [],
+            path: "UserReport/UserReport",
+            exclude: ["UserReport/UserReport/Info.plist"]
+        ),
+        .testTarget(
+            name: "UserReportTests",
+            dependencies: ["UserReportSDK"],
+            path: "UserReport/Tests",
+            exclude: ["UserReport/Tests/Info.plist"]
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -4,26 +4,26 @@
 import PackageDescription
 
 let package = Package(
-    name: "UserReport",
+    name: "UserReportSDK",
     platforms: [
         .iOS(.v9)
     ],
     products: [
         .library(
-            name: "UserReport",
-            targets: ["UserReportSDK"]
+            name: "UserReportSDK",
+            targets: ["UserReport"]
         )
     ],
     targets: [
         .target(
-            name: "UserReportSDK",
+            name: "UserReport",
             dependencies: [],
             path: "UserReport/UserReport",
             exclude: ["Info.plist"]
         ),
         .testTarget(
             name: "UserReportTests",
-            dependencies: ["UserReportSDK"],
+            dependencies: ["UserReport"],
             path: "UserReport/Tests",
             exclude: ["Info.plist"]
         )

--- a/Package.swift
+++ b/Package.swift
@@ -19,13 +19,13 @@ let package = Package(
             name: "UserReportSDK",
             dependencies: [],
             path: "UserReport/UserReport",
-            exclude: ["UserReport/UserReport/Info.plist"]
+            exclude: ["Info.plist"]
         ),
         .testTarget(
             name: "UserReportTests",
             dependencies: ["UserReportSDK"],
             path: "UserReport/Tests",
-            exclude: ["UserReport/Tests/Info.plist"]
+            exclude: ["Info.plist"]
         )
     ]
 )


### PR DESCRIPTION
This change should allow using UserReport with SPM instead of CocoaPods.

To test, create a new iOS test project and add UserReport in "File → Swift Packages → Add Package Dependency…".