### PR TITLE
fix app crash if user did not set NSUserTrackingUsageDescription param

### DIFF
--- a/UserReport/UserReport/Models/UserReportUser.swift
+++ b/UserReport/UserReport/Models/UserReportUser.swift
@@ -41,6 +41,10 @@ public class UserReportUser: NSObject {
     @objc private func getAdvertisingId() -> String {
         var advertisingId: String = ""
         
+        if Bundle.main.object(forInfoDictionaryKey: "NSUserTrackingUsageDescription") == nil {
+            return advertisingId
+        }
+        
         if UserReport.shared?.anonymousTracking == true {
             return advertisingId
         }


### PR DESCRIPTION
Application crashes if the user doesn't set NSUserTrackingUsageDescription in Info.plist. We will send "d=" in this case.